### PR TITLE
do not show FROM expression if buffer is not loaded

### DIFF
--- a/autoload/tagtracks.vim
+++ b/autoload/tagtracks.vim
@@ -72,6 +72,7 @@ function tagtracks#StartTagTracks()
   " window id whose tagstack we want to display
   const tagtracks_id = win_getid()
   new
+  setlocal nonumber
   setlocal buftype=nofile
   setlocal bufhidden=wipe
   setlocal noswapfile

--- a/autoload/tagtracks.vim
+++ b/autoload/tagtracks.vim
@@ -2,10 +2,18 @@ function tagtracks#FormatTagItem(index, item) abort
   const item_nr = a:index + 1
   const tagname = a:item.tagname
   const match = a:item.matchnr
-  const original_loc = printf('%s:%d: %s',
+
+  " getbufline() returns an empty List if the buffer passed is not loaded.
+  " So, if the file corresponding to a TagStack entry is not open, then that
+  " entry's FROM expression will not be displayed. This limitation is present
+  " in the native `:tags' command as well.
+  const text_list = getbufline(a:item.from[0], a:item.from[1])
+  const text = empty(text_list) ? '' : text_list[0]
+
+  const original_loc = printf('%s:%d %s',
         \ bufname(a:item.from[0]),
         \ a:item.from[1],
-        \ getbufline(a:item.from[0], a:item.from[1])[0])
+        \ text)
   return #{item: item_nr,
         \ tag: tagname,
         \ match: match,


### PR DESCRIPTION
Hi Ben, I came across this bug a while ago, and finally got a chance to properly address it.

Below is an example of the case addressed – the first screenshot is the output of `:tags`, and the second is the new output of `:TagTracks`. Note how one entry only has the name of the file, and line number. This file does not have an open buffer.

Let me know if any changes are needed. Thanks!

:tags
<img width="780" alt="Screen Shot 2022-02-27 at 11 13 07 PM" src="https://user-images.githubusercontent.com/42593885/155924114-b34a9685-33d2-45f3-926a-12a98334f9b7.png">

TagTracks
<img width="779" alt="Screen Shot 2022-02-27 at 11 12 36 PM" src="https://user-images.githubusercontent.com/42593885/155924144-3eaed420-59ed-4b1a-b19a-20519bdc4eb8.png">