### PR TITLE
stop TagTracks on :quit

### DIFF
--- a/autoload/tagtracks.vim
+++ b/autoload/tagtracks.vim
@@ -88,6 +88,9 @@ function tagtracks#StartTagTracks()
         \ display_id: display_id,
         \ tagtracks_id: tagtracks_id
         \ }
+
+  " stop TagTracks on :quit
+  autocmd QuitPre * call tagtracks#StopTagTracks()
 endfunction
 
 function tagtracks#StopTagTracks()


### PR DESCRIPTION
If TagTracks is not stopped before quitting, then the TagTracks window
remains open, and keeps trying to update the tag stack. Since the code
window is gone, the update fails.